### PR TITLE
Refactor/location tracker

### DIFF
--- a/Library/LocationTracker.swift
+++ b/Library/LocationTracker.swift
@@ -52,4 +52,8 @@ extension LocationTracker: CLLocationManagerDelegate {
             }
         }
     }
+    
+    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        self.delegate?.locationTracker(self, didFailWith: error)
+    }
 }

--- a/Library/LocationTracker.swift
+++ b/Library/LocationTracker.swift
@@ -1,7 +1,7 @@
 import CoreLocation
 
 protocol LocationTrackerDelegate: class {
-    func locationTracker(_ locationTracker: LocationTracker, didFailWith error: NSError)
+    func locationTracker(_ locationTracker: LocationTracker, didFailWith error: Error)
     func locationTracker(_ locationTracker: LocationTracker, didFindLocation placemark: CLPlacemark)
 }
 
@@ -45,7 +45,7 @@ extension LocationTracker: CLLocationManagerDelegate {
         let geocoder = CLGeocoder()
         geocoder.reverseGeocodeLocation(locations.first!) { placemarks, error in
             if let error = error {
-                self.delegate?.locationTracker(self, didFailWith: error as NSError)
+                self.delegate?.locationTracker(self, didFailWith: error)
             } else if let placemarks = placemarks {
                 let placemark = placemarks.first!
                 self.delegate?.locationTracker(self, didFindLocation: placemark)

--- a/iOS/Source/MainController.swift
+++ b/iOS/Source/MainController.swift
@@ -163,7 +163,7 @@ class MainController: UIViewController {
 }
 
 extension MainController: LocationTrackerDelegate {
-    func locationTracker(_ locationTracker: LocationTracker, didFailWith error: NSError) {
+    func locationTracker(_ locationTracker: LocationTracker, didFailWith error: Error) {
         self.messageLabel.text = "We need to know where you are, enable location access in your Settings."
 
         let alertController = UIAlertController(title: "Error", message: error.localizedDescription, preferredStyle: .alert)


### PR DESCRIPTION
This PR does two things 
1. Uses `Error` instead of `NSError`.
2. Adds missing `locationManager: didFailWithError:` delegate.

