### PR TITLE
Skip alert for disabled location access

### DIFF
--- a/iOS/Source/MainController.swift
+++ b/iOS/Source/MainController.swift
@@ -163,9 +163,12 @@ extension MainController: LocationTrackerDelegate {
     func locationTracker(_ locationTracker: LocationTracker, didFailWith error: Error) {
         self.messageLabel.text = "We need to know where you are, enable location access in your Settings."
 
-        let alertController = UIAlertController(title: "Error", message: error.localizedDescription, preferredStyle: .alert)
-        alertController.addAction(UIAlertAction(title: "Dismiss", style: .default, handler: nil))
-        self.present(alertController, animated: true, completion: nil)
+        let isUnexpectedError = (error as NSError).code != 0
+        if isUnexpectedError {
+            let alertController = UIAlertController(title: "Error", message: error.localizedDescription, preferredStyle: .alert)
+            alertController.addAction(UIAlertAction(title: "Dismiss", style: .default, handler: nil))
+            self.present(alertController, animated: true, completion: nil)
+        }
     }
 
     func locationTracker(_ locationTracker: LocationTracker, didFindLocation placemark: CLPlacemark) {


### PR DESCRIPTION
This PR skips displaying an alert if location access is disabled, since we already have a different way of handling that.

![simulator screen shot 3 jan 2017 15 20 09](https://cloud.githubusercontent.com/assets/1088217/21610522/c30c75ec-d1c8-11e6-8cd2-20956afbb08f.png)
