### PR TITLE
#121 Hide the status bar in onboarding

### DIFF
--- a/iOS/Source/OnboardingViewController.swift
+++ b/iOS/Source/OnboardingViewController.swift
@@ -60,6 +60,10 @@ class OnboardingViewController: UIViewController {
         }
     }
 
+    override var prefersStatusBarHidden: Bool {
+        return true
+    }
+
     lazy var titleLabel: UILabel = {
         let label = UILabel()
         label.numberOfLines = 0


### PR DESCRIPTION
Fixes: #121

![img_eb576442e91b-1](https://user-images.githubusercontent.com/1125417/46083836-87158f80-c1a2-11e8-9a62-a487937f20c3.jpeg)
